### PR TITLE
[Proposal] Add `$rememberFor` property check, to enable always caching a model

### DIFF
--- a/src/Rememberable.php
+++ b/src/Rememberable.php
@@ -16,6 +16,12 @@ trait Rememberable
 
         $grammar = $conn->getQueryGrammar();
 
-        return new Builder($conn, $grammar, $conn->getPostProcessor());
+        $builder = new Builder($conn, $grammar, $conn->getPostProcessor());
+
+        if (isset($this->rememberFor)) {
+            $builder->remember($this->rememberFor);
+        }
+
+        return $builder;
     }
 }


### PR DESCRIPTION
Love this package!

This PR adds a check for a `$rememberFor` property on the model, and if it is set, automatically adds a call to `remember($this->rememberFor)` to the `Builder`. 

This way, one can set the `$rememberFor` property on the model, and _all_ queries involving a `SELECT` for that model will back cached.

Cheers!
