### PR TITLE
Switch to SHA256 instead of MD5

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,17 @@ Using the remember method is super simple. Just pass the number of minutes you w
 
 If you want to tag certain queries you can add `cacheTags('tag_name')` to your query. Please notice that cache tags are not supported by all cache drivers.
 
-	// Remember the number of users for an hour and tag it with 'user_queries'
-	User::remember(60)->cacheTags('user_queries')->count();
+    // Remember the number of users for an hour and tag it with 'user_queries'
+    User::remember(60)->cacheTags('user_queries')->count();
+
+### Cache prefix
+
+If you want a unique prefix added to the cache key for each of your queries (say, if your cache doesn't support tagging), you can add `cachePrefix('prefix')` to your query.
+
+    // Remember the number of users for an hour and prefix the key with 'users'
+    User::remember(60)->cachePrefix('users')->count();
+
+Alternatively, you can add the `$rememberCachePrefix` property to your model to always use that cache prefix.
 
 #### Model wide cache tag
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -171,7 +171,7 @@ class Builder extends \Illuminate\Database\Query\Builder
     {
         $name = $this->connection->getName();
 
-        return md5($name.$this->toSql().serialize($this->getBindings()));
+        return hash('sha256', $name.$this->toSql().serialize($this->getBindings()));
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -177,8 +177,9 @@ class Builder extends \Illuminate\Database\Query\Builder
     public function generateCacheKey()
     {
         $name = $this->connection->getName();
+        $hash = hash('sha256', $name.$this->toSql().serialize($this->getBindings()));
 
-        return $this->cachePrefix . hash('sha256', $name.$this->toSql().serialize($this->getBindings()));
+        return $this->cachePrefix.':'.$hash;
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -13,6 +13,13 @@ class Builder extends \Illuminate\Database\Query\Builder
     protected $cacheKey;
 
     /**
+     * A prefix for caching.
+     *
+     * @var string
+     */
+    protected $cachePrefix = 'rememberable';
+
+    /**
      * The number of minutes to cache the query.
      *
      * @var int
@@ -171,7 +178,7 @@ class Builder extends \Illuminate\Database\Query\Builder
     {
         $name = $this->connection->getName();
 
-        return hash('sha256', $name.$this->toSql().serialize($this->getBindings()));
+        return $this->cachePrefix . hash('sha256', $name.$this->toSql().serialize($this->getBindings()));
     }
 
     /**
@@ -206,5 +213,15 @@ class Builder extends \Illuminate\Database\Query\Builder
 
             return $this->get($columns);
         };
+    }
+
+    /**
+     * Set the cache prefix.
+     *
+     * @param string $prefix
+     */
+    public function cachePrefix($prefix)
+    {
+        $this->cachePrefix = $prefix;
     }
 }

--- a/src/Rememberable.php
+++ b/src/Rememberable.php
@@ -26,6 +26,10 @@ trait Rememberable
             $builder->cacheTags($this->rememberCacheTag);
         }
 
+        if (isset($this->rememberCachePrefix)) {
+            $builder->cachePrefix($this->rememberCachePrefix);
+        }
+
         return $builder;
     }
 }


### PR DESCRIPTION
There are far better alternatives to md5, which don't have surprisingly feasible collisions.

This will cause people who update to have to re-fetch their query data, and their existing md5'd data will go stale and may not be removed if it was remembered forever.

Except for that, this is reasonably backwards compatible (as in it will only break if a user is relying on the query cache entirely because all tables/data have been removed, and so on).
