### PR TITLE
Add a prefix to the cache key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,17 @@ Using the remember method is super simple. Just pass the number of minutes you w
 
 If you want to tag certain queries you can add `cacheTags('tag_name')` to your query. Please notice that cache tags are not supported by all cache drivers.
 
-	// Remember the number of users for an hour and tag it with 'user_queries'
-	User::remember(60)->cacheTags('user_queries')->count();
+    // Remember the number of users for an hour and tag it with 'user_queries'
+    User::remember(60)->cacheTags('user_queries')->count();
+
+### Cache prefix
+
+If you want a unique prefix added to the cache key for each of your queries (say, if your cache doesn't support tagging), you can add `prefix('prefix')` to your query.
+
+    // Remember the number of users for an hour and prefix the key with 'users'
+    User::remember(60)->prefix('users')->count();
+
+Alternatively, you can add the ``$rememberCachePrefix` property to your model to always use that cache prefix.
 
 #### Model wide cache tag
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -166,7 +166,7 @@ class Builder extends \Illuminate\Database\Query\Builder
      */
     public function getCacheKey()
     {
-        return $this->cachePrefix.($this->cacheKey ?: $this->generateCacheKey());
+        return $this->cachePrefix.':'.($this->cacheKey ?: $this->generateCacheKey());
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -34,6 +34,13 @@ class Builder extends \Illuminate\Database\Query\Builder
     protected $cacheDriver;
 
     /**
+     * A cache prefix.
+     *
+     * @var string
+     */
+    protected $cachePrefix = 'rememberable';
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns
@@ -159,7 +166,7 @@ class Builder extends \Illuminate\Database\Query\Builder
      */
     public function getCacheKey()
     {
-        return $this->cacheKey ?: $this->generateCacheKey();
+        return $this->cachePrefix.($this->cacheKey ?: $this->generateCacheKey());
     }
 
     /**
@@ -206,5 +213,19 @@ class Builder extends \Illuminate\Database\Query\Builder
 
             return $this->get($columns);
         };
+    }
+
+    /**
+     * Set the cache prefix.
+     *
+     * @param string $prefix
+     *
+     * @return $this
+     */
+    public function prefix($prefix)
+    {
+        $this->cachePrefix = $prefix;
+
+        return $this;
     }
 }

--- a/src/Rememberable.php
+++ b/src/Rememberable.php
@@ -26,6 +26,10 @@ trait Rememberable
             $builder->cacheTags($this->rememberCacheTag);
         }
 
+        if (isset($this->rememberCachePrefix)) {
+            $builder->prefix($this->rememberCachePrefix);
+        }
+
         return $builder;
     }
 }


### PR DESCRIPTION
This means that people on, say, Redis can drop all keys that match `rememberable:*`, and people with taggable stores can still identify rememberable cache entries.
