### PR TITLE
Allow queries to be excluded from cache

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -103,6 +103,18 @@ class Builder extends \Illuminate\Database\Query\Builder
     {
         return $this->remember(-1, $key);
     }
+    
+    /**
+     * Indicate that this particular query should not be cached
+     *
+     * @return $this
+     */
+    public function doNotRemember()
+    {
+        list($this->cacheMinutes, $this->cacheKey, $this->cacheTags) = [null,null,null];
+
+        return $this;
+    }
 
     /**
      * Indicate that the results, if cached, should use the given cache tags.


### PR DESCRIPTION
This is really helpful when cache is **always enabled** for a model but in that special scenario you don't want it cached. Example usage:

```
$product->categories()->doNotRemember()->get();
```
