### PR TITLE
Check the cache store supports tags when setting

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -142,6 +142,12 @@ class Builder extends \Illuminate\Database\Query\Builder
      */
     public function cacheTags($cacheTags)
     {
+        $cache = $this->getCacheDriver();
+        
+        if ( ! method_exists($cache->getStore(), 'tags')) {
+            return $this;
+        }
+        
         $this->cacheTags = $cacheTags;
 
         return $this;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -230,7 +230,7 @@ class Builder extends \Illuminate\Database\Query\Builder
     {
         $cache = $this->getCacheDriver();
 
-        if ( ! method_exists($cache, 'tags')) {
+        if ( ! method_exists($cache->getStore(), 'tags')) {
             return false;
         }
 


### PR DESCRIPTION
Allows the use of `$model->cacheTags(...)` in the application when the cache driver doesn't support tags.

Locally I am using the file cache driver, and my live environment uses redis. This allows tags to be used without the `BadMethodCallException('This cache store does not support tagging.');` exception being thrown.