### PR TITLE
Feature/custom key names

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -42,7 +42,7 @@ class Builder extends \Illuminate\Database\Query\Builder
     protected $cachePrefix = 'rememberable';
 
     /**
-     * A cache prefix.
+     * Cache prefix for custom keys.
      *
      * @var string
      */

--- a/src/Rememberable.php
+++ b/src/Rememberable.php
@@ -31,6 +31,10 @@ trait Rememberable
             $builder->prefix($this->rememberCachePrefix);
         }
 
+        if (isset($this->rememberCustomCachePrefix)) {
+            $builder->customKeyPrefix($this->rememberCustomCachePrefix);
+        }
+
         if (isset($this->rememberCacheDriver)) {
             $builder->cacheDriver($this->rememberCacheDriver);
         }


### PR DESCRIPTION
Add ability to set a custom name to cache entries, so they can be cleared individually.
Example:
$user = User::where('id', $userId)->remember(60)->get();
would become
$user = User::where('id', $userId)->rememberKey('user:'.$userId, 60)->get();
Then on the user update, it could clear the cache for the individual user like
$user->forgetKey('user:'.$userId);
This could allow for longer caching times on entries that are frequently accessed but only occasionally updated.