### PR TITLE
Change cacheKey column name if column is object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -114,7 +114,13 @@ class Builder extends \Illuminate\Database\Query\Builder
      */
     public function pluckCached($column, $key = null)
     {
-        $cacheKey = $this->getCacheKey($column.$key);
+        $cacheKeyColumnName=$column;
+
+        if(gettype($column)=='object'){
+            $cacheKeyColumnName=$column->getValue($this->connection->getQueryGrammar());
+        }
+
+        $cacheKey = $this->getCacheKey($cacheKeyColumnName.$key);
 
         $seconds = $this->cacheSeconds;
 


### PR DESCRIPTION
Change cacheKey column name if column is object.
for example if column type is in Raw format we got a exception