### PR TITLE
Add PHPDocs for PHPStan

### DIFF
--- a/src/Rememberable.php
+++ b/src/Rememberable.php
@@ -4,6 +4,24 @@ namespace Watson\Rememberable;
 
 use Watson\Rememberable\Query\Builder;
 
+/**
+ * @method static array getCached(array $columns = ['*'])
+ * @method static array pluckCached(string $column, mixed $key = null)
+ * @method static \Illuminate\Database\Query\Builder|\Watson\Rememberable\Query\Builder remember(\DateTime|int $seconds, string $key = null)
+ * @method static \Illuminate\Database\Query\Builder|\Watson\Rememberable\Query\Builder rememberForever(string $key = null)
+ * @method static \Illuminate\Database\Query\Builder|\Watson\Rememberable\Query\Builder dontRemember()
+ * @method static \Illuminate\Database\Query\Builder|\Watson\Rememberable\Query\Builder doNotRemember()
+ * @method static \Illuminate\Database\Query\Builder|\Watson\Rememberable\Query\Builder prefix(string $prefix)
+ * @method static \Illuminate\Database\Query\Builder|\Watson\Rememberable\Query\Builder cacheTags(array|mixed $cacheTags)
+ * @method static \Illuminate\Database\Query\Builder|\Watson\Rememberable\Query\Builder cacheDriver(string $cacheDriver)
+ * @method static \Illuminate\Cache\CacheManager getCache()
+ * @method static \Illuminate\Cache\CacheManager getCacheDriver()
+ * @method static string getCacheKey(mixed $appends = null)
+ * @method static string generateCacheKey(mixed $appends = null)
+ * @method static boolean flushCache(mixed $cacheTags = null)
+ * @method static \Closure getCacheCallback(array $columns)
+ * @method static \Closure pluckCacheCallback(string $column, mixed $key = null)
+ */
 trait Rememberable
 {
     /**


### PR DESCRIPTION
Currently PHPStan errors whenever we use User::dontRemember()->find($id).

This adds PHPDocs to the Rememberable trait so PHPStan understands that these methods are added by your package.